### PR TITLE
Add reference to location via easy_install

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ can use. Next step is to download Pygments:
 
     $ hg clone http://dev.pocoo.org/hg/pygments-main pygments
 
+If it is already installed via easy_install, check `/Library/Python/2.X/site-packages/`
+
 And then you will install your new theme:
 
     $ cd pygments


### PR DESCRIPTION
I don't use python, and I'm sure a few others are the same, this just adds a reference to where you can find pygments  if its already installed.
